### PR TITLE
fix the diff sanity check to check if blocks have been removed via their hash method...

### DIFF
--- a/lib/dyph3/support/sanity_check.rb
+++ b/lib/dyph3/support/sanity_check.rb
@@ -35,8 +35,8 @@ module Dyph3
       private
         def count_blocks(blocks, hash={})
           blocks.reduce(hash) do |map, block|
-            map[block.inspect] ||= 0
-            map[block.inspect] += 1
+            map[block] ||= 0
+            map[block] += 1
             map
           end
         end


### PR DESCRIPTION
... instead of via their inspect method.

This fixes a bug that was raising BadMergeExceptions on objects that overrode their equals and hash methods, but not their inspect method.