### PR TITLE
RFR: refactor merge results into something clearer

### DIFF
--- a/lib/dyph3.rb
+++ b/lib/dyph3.rb
@@ -1,6 +1,10 @@
 require "dyph3/version"
 require "dyph3/differ"
 
+require "dyph3/merge_result"
+require "dyph3/merge_result/success"
+require "dyph3/merge_result/conflict"
+
 require "dyph3/support/diff3"
 require "dyph3/support/collater"
 require "dyph3/support/merger"

--- a/lib/dyph3/differ.rb
+++ b/lib/dyph3/differ.rb
@@ -19,7 +19,7 @@ module Dyph3
       merge_result = Dyph3::Support::Merger.merge(left, base, right, current_differ: current_differ)
       collated_merge_results = Dyph3::Support::Collater.collate_merge(merge_result, join_function, conflict_function)
       if collated_merge_results.success?
-        Dyph3::Support::SanityCheck.ensure_no_lost_data(left, base, right, collated_merge_results.value)
+        Dyph3::Support::SanityCheck.ensure_no_lost_data(left, base, right, collated_merge_results.results)
       end
 
       collated_merge_results

--- a/lib/dyph3/differ.rb
+++ b/lib/dyph3/differ.rb
@@ -17,19 +17,12 @@ module Dyph3
       left, base, right = [left, base, right].map { |t| split_function.call(t) }
 
       merge_result = Dyph3::Support::Merger.merge(left, base, right, current_differ: current_differ)
-      return_value = Dyph3::Support::Collater.collate_merge(left, base, right, merge_result)
-
-      # sanity check: make sure anything new in left or right made it through the merge
-      if has_conflict(return_value) && conflict_function
-        conflict_function[return_value]
-      else
-        Dyph3::Support::SanityCheck.ensure_no_lost_data(left, base, right, return_value)
-        join_results(return_value, join_function: join_function)
+      collated_merge_results = Dyph3::Support::Collater.collate_merge(merge_result, join_function, conflict_function)
+      if collated_merge_results.success?
+        Dyph3::Support::SanityCheck.ensure_no_lost_data(left, base, right, collated_merge_results.value)
       end
-    end
 
-    def self.has_conflict(return_value)
-      return_value[1] #conflict indicator index
+      collated_merge_results
     end
 
     def self.split_on_new_line
@@ -39,25 +32,5 @@ module Dyph3
     def self.standard_join
       -> (array) { array.join }
     end
-
-    def self.join_results(old_results, join_function:)
-      new_results = []
-      new_results[0] = join_function.call old_results[0]
-      new_results[1] = old_results[1]
-
-      new_results[2] = old_results[2].map do |hash|
-        return_hash = {}
-        hash.keys.map do |key|
-          if key == :type
-            return_hash[key] = hash[key]
-          else
-            return_hash[key] = join_function.call(hash[key])
-          end
-        end
-        return_hash
-      end
-      new_results
-    end
   end
-
 end

--- a/lib/dyph3/merge_result.rb
+++ b/lib/dyph3/merge_result.rb
@@ -1,0 +1,19 @@
+module Dyph3
+  class MergeResult
+    attr_reader :value
+    def initialize(value, post_processor)
+      @value = value
+      @post_processor = post_processor
+    end
+
+    def success?
+      self.class == Dyph3::MergeResult::Success
+    end
+
+    def conflict?
+      self.class == Dyph3::MergeResult::Conflict
+    end
+  end
+
+
+end

--- a/lib/dyph3/merge_result.rb
+++ b/lib/dyph3/merge_result.rb
@@ -1,8 +1,8 @@
 module Dyph3
   class MergeResult
-    attr_reader :value
-    def initialize(value, join_function, conflict_handler=nil)
-      @value = value
+    attr_reader :results
+    def initialize(results, join_function, conflict_handler=nil)
+      @results = results
       @join_function = join_function
       @conflict_handler = conflict_handler
     end
@@ -16,7 +16,8 @@ module Dyph3
     end
 
     def typed_results
-      value.map do |hash|
+      #results but with the joined function applied to the text fields
+      results.map do |hash|
         return_hash = {}
         hash.keys.map do |key|
           if key == :type

--- a/lib/dyph3/merge_result.rb
+++ b/lib/dyph3/merge_result.rb
@@ -1,9 +1,10 @@
 module Dyph3
   class MergeResult
     attr_reader :value
-    def initialize(value, post_processor)
+    def initialize(value, join_function, conflict_handler=nil)
       @value = value
-      @post_processor = post_processor
+      @join_function = join_function
+      @conflict_handler = conflict_handler
     end
 
     def success?
@@ -12,6 +13,20 @@ module Dyph3
 
     def conflict?
       self.class == Dyph3::MergeResult::Conflict
+    end
+
+    def typed_results
+      value.map do |hash|
+        return_hash = {}
+        hash.keys.map do |key|
+          if key == :type
+            return_hash[key] = hash[key]
+          else
+            return_hash[key] = @join_function.call(hash[key])
+          end
+        end
+        return_hash
+      end
     end
   end
 

--- a/lib/dyph3/merge_result/conflict.rb
+++ b/lib/dyph3/merge_result/conflict.rb
@@ -1,7 +1,11 @@
 module Dyph3
   class MergeResult::Conflict < Dyph3::MergeResult
-    def results
-      @post_processor[value]
+    def joined_results
+      if @conflict_handler
+        @conflict_handler[value]
+      else
+        typed_results
+      end
     end
   end
 end

--- a/lib/dyph3/merge_result/conflict.rb
+++ b/lib/dyph3/merge_result/conflict.rb
@@ -1,0 +1,7 @@
+module Dyph3
+  class MergeResult::Conflict < Dyph3::MergeResult
+    def results
+      @post_processor[value]
+    end
+  end
+end

--- a/lib/dyph3/merge_result/conflict.rb
+++ b/lib/dyph3/merge_result/conflict.rb
@@ -1,8 +1,9 @@
 module Dyph3
   class MergeResult::Conflict < Dyph3::MergeResult
     def joined_results
+      #allows for custom conflict handler
       if @conflict_handler
-        @conflict_handler[value]
+        @conflict_handler[results]
       else
         typed_results
       end

--- a/lib/dyph3/merge_result/success.rb
+++ b/lib/dyph3/merge_result/success.rb
@@ -1,0 +1,7 @@
+module Dyph3
+  class MergeResult::Success < Dyph3::MergeResult
+    def results
+      @post_processor[value[0][:text]]
+    end
+  end
+end

--- a/lib/dyph3/merge_result/success.rb
+++ b/lib/dyph3/merge_result/success.rb
@@ -1,7 +1,7 @@
 module Dyph3
   class MergeResult::Success < Dyph3::MergeResult
-    def results
-      @post_processor[value[0][:text]]
+    def joined_results
+      @join_function[value[0][:text]]
     end
   end
 end

--- a/lib/dyph3/merge_result/success.rb
+++ b/lib/dyph3/merge_result/success.rb
@@ -1,7 +1,9 @@
 module Dyph3
   class MergeResult::Success < Dyph3::MergeResult
     def joined_results
-      @join_function[value[0][:text]]
+      # in a success the results is only one non-conflict
+      # e.g.[{type: :non_conflict, text: ["..."]}]
+      @join_function[results[0][:text]]
     end
   end
 end

--- a/lib/dyph3/support/collater.rb
+++ b/lib/dyph3/support/collater.rb
@@ -10,26 +10,12 @@ module Dyph3
           if (merge_result.length == 1 && merge_result[0][:type] == :non_conflict)
             Dyph3::MergeResult::Success.new([{type: :non_conflict, text: merge_result[0][:text]}], join_function)
           else
-            Dyph3::MergeResult::Conflict.new(merge_result, conflict_function || ->(result) { apply_join_function(result, join_function) })
+            Dyph3::MergeResult::Conflict.new(merge_result, join_function, conflict_function)
           end
         end
       end
 
       private
-
-        def apply_join_function(result, join_function)
-          result.map do |hash|
-            return_hash = {}
-            hash.keys.map do |key|
-              if key == :type
-                return_hash[key] = hash[key]
-              else
-                return_hash[key] = join_function.call(hash[key])
-              end
-            end
-            return_hash
-          end
-        end
         # @param [in] conflicts
         # @returns the list of conflicts with contiguous parts merged if they are non_conflicts
         def merge_non_conflicts(res, i = 0)

--- a/lib/dyph3/support/sanity_check.rb
+++ b/lib/dyph3/support/sanity_check.rb
@@ -3,11 +3,8 @@ module Dyph3
     module SanityCheck
       extend self
 
-      def ensure_no_lost_data(left, base, right, return_value)
-        final_result = return_value[2]
-
+      def ensure_no_lost_data(left, base, right, final_result)
         result_word_map = {}
-
         final_result.each do |result_block|
           blocks = case result_block[:type]
             when :non_conflict then result_block[:text]
@@ -28,7 +25,7 @@ module Dyph3
         missing_new_right_words = subtract_words(new_right_words, result_word_map)
 
         if missing_new_left_words.any? || missing_new_right_words.any?
-          raise BadMergeException.new(return_value)
+          raise BadMergeException.new(final_result)
         end
       end
 

--- a/spec/fixtures/animal.rb
+++ b/spec/fixtures/animal.rb
@@ -16,7 +16,7 @@ class Fish
   DIFF_PREPROCESSOR = -> (animal) { [animal.type] }
   DIFF_POSTPROCESSOR = -> (animal_array) { Fish.new(animal_array.first) }
   DIFF_CONFLICT_PROCESSOR = ->(differ_output) do
-    differ_output[2].first[:conflict_custom] = [:tuna]
+    differ_output.first[:conflict_custom] = [:tuna]
     differ_output
   end
   attr_accessor :type
@@ -32,7 +32,7 @@ end
 
 class Bird
   include Animal
-  
+
   attr_accessor :type
   def initialize(type)
     @type = type

--- a/spec/lib/dyph3/differ_spec.rb
+++ b/spec/lib/dyph3/differ_spec.rb
@@ -11,7 +11,7 @@ describe Dyph3::Differ do
           base =  "ants bears cat dog".split
           right =  "ants elephant cat bears dog".split
           merge_result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(merge_result.results).to eq right
+          expect(merge_result.joined_results).to eq right
           expect(merge_result.success?).to be true
         end
 
@@ -20,7 +20,7 @@ describe Dyph3::Differ do
           base =  "ants bears cat dog".split
           left =  "ants elephant cat bears dog".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result.results).to eq left
+          expect(result.joined_results).to eq left
           expect(result.success?).to be true
         end
 
@@ -29,7 +29,7 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "ants elephant cat bears".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result.results).to eq right
+          expect(result.joined_results).to eq right
           expect(result.success?).to be true
         end
 
@@ -38,7 +38,7 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "bears ants cat elephant".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result.results).to eq right
+          expect(result.joined_results).to eq right
           expect(result.success?).to be true
         end
 
@@ -47,7 +47,7 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "elephant ants cat bears".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result.results).to eq right
+          expect(result.joined_results).to eq right
           expect(result.success?).to be true
         end
 
@@ -56,7 +56,7 @@ describe Dyph3::Differ do
           base =  "ant bear cat monkey".split
           right = "ant cat bear dog elephant monkey goat".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result.results).to eq right
+          expect(result.joined_results).to eq right
           expect(result.success?).to be true
         end
 
@@ -67,7 +67,7 @@ describe Dyph3::Differ do
 
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity, join_function: identity, current_differ: current_differ)
 
-          expect(result.results).to eq right
+          expect(result.joined_results).to eq right
           expect(result.success?).to be true
         end
       end
@@ -83,7 +83,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successuffly" do
-          expect(merged_array.results).to eq right
+          expect(merged_array.joined_results).to eq right
         end
       end
 
@@ -97,7 +97,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successfully" do
-          expect(merged_array.results).to eq right
+          expect(merged_array.joined_results).to eq right
         end
       end
       describe "test conflict function" do
@@ -110,7 +110,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successfully" do
-          expect(merged_array.results.first[:conflict_custom]).to eq [:tuna]
+          expect(merged_array.joined_results.first[:conflict_custom]).to eq [:tuna]
         end
       end
 
@@ -129,22 +129,22 @@ describe Dyph3::Differ do
 
         it "should not explode" do
           res = Dyph3::Differ.merge_text(left, base, right, join_function: ->(x) { x } )
-          expect(res.results).to eq expected_result
+          expect(res.joined_results).to eq expected_result
         end
 
         it "should not be conflicted when not conflicted" do
           result = Dyph3::Differ.merge_text(left, base, left)
-          expect(result.results).to eq left
+          expect(result.joined_results).to eq left
         end
 
         it "should not be conflicted with the same text" do
           result = Dyph3::Differ.merge_text(left, left, left)
-          expect(result.results).to eq left
+          expect(result.joined_results).to eq left
         end
 
         it "should not be conflicted when not conflicted" do
           result = Dyph3::Differ.merge_text(base, base, base)
-          expect(result.results).to eq base
+          expect(result.joined_results).to eq base
         end
 
         # issue adding \n to the beginning and end of a line
@@ -154,7 +154,7 @@ describe Dyph3::Differ do
           right = "Article title"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result.results).to eq left
+          expect(result.joined_results).to eq left
         end
 
         it "should handle one side unchanged" do
@@ -163,12 +163,12 @@ describe Dyph3::Differ do
           right = "Article title"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result.results).to eq left
+          expect(result.joined_results).to eq left
         end
 
         it "should handle empty strings" do
           result = Dyph3::Differ.merge_text("", "", "")
-          expect(result.results).to eq ""
+          expect(result.joined_results).to eq ""
         end
 
         it "should handle null inputs" do
@@ -194,7 +194,7 @@ describe Dyph3::Differ do
 
         it "should produce a conflict" do
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result.results).to eq expected_result
+          expect(result.joined_results).to eq expected_result
           expect(result.conflict?).to eq true
         end
       end
@@ -210,7 +210,7 @@ describe Dyph3::Differ do
               {type: :conflict, ours: "THIS IS some text\n", base: "this is some text\n", theirs: "THIS IS SOME TEXT\n"},
               {type: :non_conflict, text: "another line of text\none more good line\nthats about it now\nthis is the last line\n"}]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
           expect(result.conflict?).to eq(true)
         end
 
@@ -222,7 +222,7 @@ describe Dyph3::Differ do
               {type: :conflict, ours: "thats about it NOW\nTHIS is the last line\n", base: "thats about it now\nthis is the last line\n", theirs: "thats about it no\nTHIS is the LAST LINE\n"}
           ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
           expect(result.conflict?).to eq(true)
 
         end
@@ -235,7 +235,7 @@ describe Dyph3::Differ do
               {type: :non_conflict, text: "thats about it now\nthis is the last line\n"}
             ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
           expect(result.conflict?).to eq(true)
         end
 
@@ -250,7 +250,7 @@ describe Dyph3::Differ do
               {type: :non_conflict, text: "this is the last line\n"}
             ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
 
           expected_result_reversed = [
             {type: :non_conflict, text: "this is some text\n"},
@@ -260,7 +260,7 @@ describe Dyph3::Differ do
             {type: :non_conflict, text: "this is the last line\n"}
           ]
           result_reversed = Dyph3::Differ.merge_text(theirs, base, ours)
-          expect(result_reversed.results).to eq(expected_result_reversed)
+          expect(result_reversed.joined_results).to eq(expected_result_reversed)
         end
 
         it 'should handle a conflict, non_conflict, conflict pattern' do
@@ -273,7 +273,7 @@ describe Dyph3::Differ do
             {type: :non_conflict, text: "B\n"},
             {type: :conflict, ours: "C\n", base: "cc\n", theirs: "c\n" }
           ]
-          expect(result.results).to eq (expected_result)
+          expect(result.joined_results).to eq (expected_result)
         end
 
         it 'should handle periodic conflicts' do
@@ -289,7 +289,7 @@ describe Dyph3::Differ do
             {type: :conflict, ours: "WOOHOO!\n", base:"woohoo!\n", theirs:"wooHOO!\n"}
           ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq expected_result
+          expect(result.joined_results).to eq expected_result
           expect(result.conflict?).to eq true
         end
 
@@ -300,7 +300,7 @@ describe Dyph3::Differ do
           expected_string = "this is some text\nANOTHER LINE OF TEXT\none more good line\nthats ABOUT it now\nthis is the last line\n"
           expected_result = expected_string
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
           expect(result.success?).to eq(true)
         end
 
@@ -315,7 +315,7 @@ describe Dyph3::Differ do
               {:type=>:non_conflict, :text=>"another line of text"}
             ]
             result = Dyph3::Differ.merge_text(ours, base, theirs)
-            expect(result.results).to eq(expected_result)
+            expect(result.joined_results).to eq(expected_result)
             expect(result.conflict?).to eq(true)
           end
 
@@ -333,7 +333,7 @@ describe Dyph3::Differ do
               { :type=>:non_conflict, :text=>"another line of text"}
             ]
             result = Dyph3::Differ.merge_text(ours, base, theirs)
-            expect(result.results).to eq(expected_result)
+            expect(result.joined_results).to eq(expected_result)
           end
         end
 
@@ -343,7 +343,7 @@ describe Dyph3::Differ do
           theirs = 'apricot'
           result = Dyph3::Differ.merge_text(ours, base, theirs)
           expected_result = [{type: :conflict, ours: "apple", base: "", theirs: "apricot"}]
-          expect(result.results).to eq(expected_result)
+          expect(result.joined_results).to eq(expected_result)
         end
       end
 
@@ -352,31 +352,31 @@ describe Dyph3::Differ do
         non_trailing = "hi\nthis is text"
         it 'should not have a trailing newline where expected' do
           result1 = Dyph3::Differ.merge_text(non_trailing, non_trailing, non_trailing)
-          expect(result1.results[-1]).to_not eq("\n")
+          expect(result1.joined_results[-1]).to_not eq("\n")
           
           result2 = Dyph3::Differ.merge_text(non_trailing, trailing, non_trailing)
-          expect(result2.results[-1]).to_not eq("\n")
+          expect(result2.joined_results[-1]).to_not eq("\n")
           
           result3 = Dyph3::Differ.merge_text(non_trailing, trailing, trailing)
-          expect(result3.results[-1]).to_not eq("\n")
+          expect(result3.joined_results[-1]).to_not eq("\n")
           
           result4 = Dyph3::Differ.merge_text(trailing, trailing, non_trailing)
-          expect(result4.results[-1]).to_not eq("\n")
+          expect(result4.joined_results[-1]).to_not eq("\n")
         end
 
         it 'should have a trailing newline where expected' do
           result1 = Dyph3::Differ.merge_text(non_trailing, non_trailing, trailing)
-          expect(result1.results).to eq(trailing)
-          expect(result1.results[-1]).to eq("\n")
+          expect(result1.joined_results).to eq(trailing)
+          expect(result1.joined_results[-1]).to eq("\n")
 
           result2 = Dyph3::Differ.merge_text(trailing, non_trailing, non_trailing)
-          expect(result2.results[-1]).to eq("\n")
+          expect(result2.joined_results[-1]).to eq("\n")
 
           result3 = Dyph3::Differ.merge_text(trailing, non_trailing, trailing)
-          expect(result3.results[-1]).to eq("\n")
+          expect(result3.joined_results[-1]).to eq("\n")
 
           result4 = Dyph3::Differ.merge_text(trailing, trailing, trailing)
-          expect(result4.results[-1]).to eq("\n")
+          expect(result4.joined_results[-1]).to eq("\n")
 
         end
 
@@ -386,7 +386,7 @@ describe Dyph3::Differ do
           right = "\n<p>\nSome stuff\nAnd another line here\n</p>\nMore stuff here\n"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result.results).to eq ['', '<p>', 'Some stuff', 'Added a line here', 'And another line here', '</p>', 'More stuff here', ''].join("\n")
+          expect(result.joined_results).to eq ['', '<p>', 'Some stuff', 'Added a line here', 'And another line here', '</p>', 'More stuff here', ''].join("\n")
         end
 
         it "spot a conflict when left right and base don't agree" do
@@ -401,7 +401,7 @@ describe Dyph3::Differ do
             {type: :non_conflict, text: "</p>\n"}
           ]
           merged_text = Dyph3::Differ.merge_text(left, base, right)
-          expect(merged_text.results).to eql expected_result
+          expect(merged_text.joined_results).to eql expected_result
         end
       end
     end

--- a/spec/lib/dyph3/differ_spec.rb
+++ b/spec/lib/dyph3/differ_spec.rb
@@ -10,9 +10,9 @@ describe Dyph3::Differ do
           left =  "ants bears cat dog".split
           base =  "ants bears cat dog".split
           right =  "ants elephant cat bears dog".split
-          result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          merge_result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
+          expect(merge_result.results).to eq right
+          expect(merge_result.success?).to be true
         end
 
         it "should handle when base and right match" do
@@ -20,8 +20,8 @@ describe Dyph3::Differ do
           base =  "ants bears cat dog".split
           left =  "ants elephant cat bears dog".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq left
-          expect(result[1]).to be false
+          expect(result.results).to eq left
+          expect(result.success?).to be true
         end
 
         it "should handle when base and left match" do
@@ -29,8 +29,8 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "ants elephant cat bears".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          expect(result.results).to eq right
+          expect(result.success?).to be true
         end
 
         it "should handle when the first elements are switched and an insert at the end" do
@@ -38,8 +38,8 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "bears ants cat elephant".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          expect(result.results).to eq right
+          expect(result.success?).to be true
         end
 
         it "should handle when the last elements are switched and an insert at the beginning" do
@@ -47,8 +47,8 @@ describe Dyph3::Differ do
           base =  "ants bears cat".split
           right =  "elephant ants cat bears".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          expect(result.results).to eq right
+          expect(result.success?).to be true
         end
 
         it "should handle when all three are different" do
@@ -56,8 +56,8 @@ describe Dyph3::Differ do
           base =  "ant bear cat monkey".split
           right = "ant cat bear dog elephant monkey goat".split
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity , join_function: identity, current_differ: current_differ)
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          expect(result.results).to eq right
+          expect(result.success?).to be true
         end
 
         it "should handle this really complex real-world case" do
@@ -67,8 +67,8 @@ describe Dyph3::Differ do
 
           result = Dyph3::Differ.merge_text(left, base, right, split_function: identity, join_function: identity, current_differ: current_differ)
 
-          expect(result[0]).to eq right
-          expect(result[1]).to be false
+          expect(result.results).to eq right
+          expect(result.success?).to be true
         end
       end
 
@@ -83,7 +83,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successuffly" do
-          expect(merged_array[0]).to eq right
+          expect(merged_array.results).to eq right
         end
       end
 
@@ -97,7 +97,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successfully" do
-          expect(merged_array[0]).to eq right
+          expect(merged_array.results).to eq right
         end
       end
       describe "test conflict function" do
@@ -110,7 +110,7 @@ describe Dyph3::Differ do
         end
 
         it "should have merged successfully" do
-          expect(merged_array.last.last[:conflict_custom]).to eq [:tuna]
+          expect(merged_array.results.first[:conflict_custom]).to eq [:tuna]
         end
       end
 
@@ -121,34 +121,30 @@ describe Dyph3::Differ do
 
         let(:right) {"This is the baseline.\nThe start.\nB added this line.\nThe end.\ncats\ndogs\npigs\ncows\nchickens"}
 
-        let(:expected_result){[
-          base,
-          true,
-          [{type: :non_conflict, text: "This is the baseline.\n"},
-          {type: :conflict, ours: "The start (changed by A).\n", base: "The start.\n", theirs: "The start.\nB added this line.\n"},
-          {type: :non_conflict, text: "The end.\ncats\ndogs\npigs\ncows\nchickens"}]]
+        let(:expected_result){
+          [{type: :non_conflict, text: ["This is the baseline.\n"]},
+          {type: :conflict, ours: ["The start (changed by A).\n"], base: ["The start.\n"], theirs: ["The start.\n","B added this line.\n"]},
+          {type: :non_conflict, text: ["The end.\n","cats\n","dogs\n","pigs\n","cows\n","chickens"]}]
         }
 
         it "should not explode" do
-          res = Dyph3::Differ.merge_text(left, base, right )
-          expect(res).to eq expected_result
+          res = Dyph3::Differ.merge_text(left, base, right, join_function: ->(x) { x } )
+          expect(res.results).to eq expected_result
         end
 
         it "should not be conflicted when not conflicted" do
           result = Dyph3::Differ.merge_text(left, base, left)
-          expecting = left
-          expect(result).to eq [left, false, [{type: :non_conflict, text: left}]]
+          expect(result.results).to eq left
         end
 
         it "should not be conflicted with the same text" do
           result = Dyph3::Differ.merge_text(left, left, left)
-          expecting = left
-          expect(result).to eq [left, false, [{type: :non_conflict, text: left}]]
+          expect(result.results).to eq left
         end
 
         it "should not be conflicted when not conflicted" do
           result = Dyph3::Differ.merge_text(base, base, base)
-          expect(result).to eq [base, false, [{type: :non_conflict, text: base}]]
+          expect(result.results).to eq base
         end
 
         # issue adding \n to the beginning and end of a line
@@ -158,7 +154,7 @@ describe Dyph3::Differ do
           right = "Article title"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result).to eq [left, false, [{type: :non_conflict, text: left}]]
+          expect(result.results).to eq left
         end
 
         it "should handle one side unchanged" do
@@ -167,12 +163,12 @@ describe Dyph3::Differ do
           right = "Article title"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result).to eq [left, false, [{type: :non_conflict, text: left}]]
+          expect(result.results).to eq left
         end
 
         it "should handle empty strings" do
           result = Dyph3::Differ.merge_text("", "", "")
-          expect(result).to eq ["", false, [{type: :non_conflict, text: ""}]]
+          expect(result.results).to eq ""
         end
 
         it "should handle null inputs" do
@@ -189,21 +185,17 @@ describe Dyph3::Differ do
         left = """\n<h2>\nThis is cool.\n</h2>\n<p>\nHi I'm a paragraph.\nI'm another sentence in the paragraph.\n</p>"""
         right = """\n<h2>\nThis is cool.\n</h2>\n<p>\n Hi I'm a paragraph.\nI'm a second sentence in the paragraph.\n</p>"""
         base = """\n<h2>\nThis is cool.\n</h2>\n<p>\n Hi I'm a paragraph.\nI'm a sentence in the paragraph.\n</p>"""
-        expected_result = [
-          base,
-          true,
+        expected_result =
           [ {type: :non_conflict, text: "\n<h2>\nThis is cool.\n</h2>\n<p>\n"},
             {type: :conflict, ours: "Hi I'm a paragraph.\nI'm another sentence in the paragraph.\n", 
                               theirs: " Hi I'm a paragraph.\nI'm a second sentence in the paragraph.\n",
                               base: " Hi I'm a paragraph.\nI'm a sentence in the paragraph.\n"},
-            {type: :non_conflict, text: "</p>"}]]
+            {type: :non_conflict, text: "</p>"}]
 
         it "should produce a conflict" do
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result.length).to be > 0
-          expect(result[0]).to eq expected_result[0]
-          expect(result[1]).to eq expected_result[1]
-          expect(result[2]).to eq expected_result[2]
+          expect(result.results).to eq expected_result
+          expect(result.conflict?).to eq true
         end
       end
 
@@ -215,59 +207,60 @@ describe Dyph3::Differ do
           ours = "THIS IS some text\nanother line of text\none more good line\nthats about it now\nthis is the last line\n"
           theirs = "THIS IS SOME TEXT\nanother line of text\none more good line\nthats about it now\nthis is the last line\n"
           expected_result = [
-            base,
-            true,
-            [ {type: :conflict, ours: "THIS IS some text\n", base: "this is some text\n", theirs: "THIS IS SOME TEXT\n"},
-              {type: :non_conflict, text: "another line of text\none more good line\nthats about it now\nthis is the last line\n"}]]
+              {type: :conflict, ours: "THIS IS some text\n", base: "this is some text\n", theirs: "THIS IS SOME TEXT\n"},
+              {type: :non_conflict, text: "another line of text\none more good line\nthats about it now\nthis is the last line\n"}]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq(expected_result)
+          expect(result.results).to eq(expected_result)
+          expect(result.conflict?).to eq(true)
         end
+
         it 'should have a conflict in the last line' do
           ours = "this is some text\nanother line of text\none more good line\nthats about it NOW\nTHIS is the last line\n"
           theirs="this is some text\nanother line of text\none more good line\nthats about it no\nTHIS is the LAST LINE\n"
           expected_result = [
-            base,
-            true,
-            [ {type: :non_conflict, text: "this is some text\nanother line of text\none more good line\n"},
-              {type: :conflict, ours: "thats about it NOW\nTHIS is the last line\n", base: "thats about it now\nthis is the last line\n", theirs: "thats about it no\nTHIS is the LAST LINE\n"}]]
+              {type: :non_conflict, text: "this is some text\nanother line of text\none more good line\n"},
+              {type: :conflict, ours: "thats about it NOW\nTHIS is the last line\n", base: "thats about it now\nthis is the last line\n", theirs: "thats about it no\nTHIS is the LAST LINE\n"}
+          ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq(expected_result)
+          expect(result.results).to eq(expected_result)
+          expect(result.conflict?).to eq(true)
+
         end
         it 'should have a single conflict in between non_conflicts' do
           ours = "this is some text\nanother line of text\none more BAD line\nwe inserted a line\nthats about it now\nthis is the last line\n"
           theirs = "this is some text\nanother line of text\none more GREAT line\nthey inserted a line\nthats about it now\nthis is the last line\n"
           expected_result = [
-            base,
-            true,
-            [ {type: :non_conflict, text: "this is some text\nanother line of text\n"},
+            {type: :non_conflict, text: "this is some text\nanother line of text\n"},
               {type: :conflict, ours: "one more BAD line\nwe inserted a line\n", base: "one more good line\n", theirs: "one more GREAT line\nthey inserted a line\n"},
-              {type: :non_conflict, text: "thats about it now\nthis is the last line\n"}]]
+              {type: :non_conflict, text: "thats about it now\nthis is the last line\n"}
+            ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq(expected_result)
+          expect(result.results).to eq(expected_result)
+          expect(result.conflict?).to eq(true)
         end
+
         it 'should handle overlapping conflicts' do
           ours   = "this is some text\nanother LINE of text\none more GREAT line\nthats about it now\nthis is the last line\n"
           theirs = "this is some text\nanother line of text\none more GOOD line\nthats ABOUT it now\nthis is the last line\n"
-          expected_result = [
-            base,
-            true,
+          expected_result =
             [ {type: :non_conflict, text: "this is some text\n"},
               {type: :conflict, ours: "another LINE of text\none more GREAT line\nthats about it now\n", 
                                 base: "another line of text\none more good line\nthats about it now\n", 
                                 theirs: "another line of text\none more GOOD line\nthats ABOUT it now\n"},
-              {type: :non_conflict, text: "this is the last line\n"}]]
+              {type: :non_conflict, text: "this is the last line\n"}
+            ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq(expected_result)
+          expect(result.results).to eq(expected_result)
+
           expected_result_reversed = [
-            base,
-            true,
-            [ {type: :non_conflict, text: "this is some text\n"},
-              {type: :conflict, theirs: "another LINE of text\none more GREAT line\nthats about it now\n", 
-                                base: "another line of text\none more good line\nthats about it now\n", 
-                                ours: "another line of text\none more GOOD line\nthats ABOUT it now\n"},
-              {type: :non_conflict, text: "this is the last line\n"}]]
+            {type: :non_conflict, text: "this is some text\n"},
+            {type: :conflict, theirs: "another LINE of text\none more GREAT line\nthats about it now\n", 
+                              base: "another line of text\none more good line\nthats about it now\n", 
+                              ours: "another line of text\none more GOOD line\nthats ABOUT it now\n"},
+            {type: :non_conflict, text: "this is the last line\n"}
+          ]
           result_reversed = Dyph3::Differ.merge_text(theirs, base, ours)
-          expect(result_reversed).to eq(expected_result_reversed)
+          expect(result_reversed.results).to eq(expected_result_reversed)
         end
 
         it 'should handle a conflict, non_conflict, conflict pattern' do
@@ -276,27 +269,28 @@ describe Dyph3::Differ do
           base_text = "aa\nB\ncc\n"
           result = Dyph3::Differ.merge_text(our_text, base_text, their_text)
           expected_result = [
-            base_text, 
-            true, 
-            [{type: :conflict, ours: "A\n", base: "aa\n", theirs: "a\n" },
+            {type: :conflict, ours: "A\n", base: "aa\n", theirs: "a\n" },
             {type: :non_conflict, text: "B\n"},
-            {type: :conflict, ours: "C\n", base: "cc\n", theirs: "c\n" }]]
-          expect(result).to eq (expected_result)
+            {type: :conflict, ours: "C\n", base: "cc\n", theirs: "c\n" }
+          ]
+          expect(result.results).to eq (expected_result)
         end
 
         it 'should handle periodic conflicts' do
           base   += "woohoo!\n"
           ours    = "this is some text\nANOTHER LINE OF TEXT\none more good line\nthats about IT now\nthis is the last line\nWOOHOO!\n"
           theirs  = "this is some text\nanother LINE of text\none more good line\nthats ABOUT it now\nthis is the last line\nwooHOO!\n"
-          expected_result = [base, true, 
-            [{type: :non_conflict, text: "this is some text\n"},
-             {type: :conflict, ours:"ANOTHER LINE OF TEXT\n",  base: "another line of text\n", theirs:"another LINE of text\n"},
-             {type: :non_conflict, text: "one more good line\n"},
-             {type: :conflict, ours:"thats about IT now\n", base:"thats about it now\n", theirs: "thats ABOUT it now\n"},
-             {type: :non_conflict, text: "this is the last line\n"},
-             {type: :conflict, ours: "WOOHOO!\n", base:"woohoo!\n", theirs:"wooHOO!\n"}]]
+          expected_result = [
+            {type: :non_conflict, text: "this is some text\n"},
+            {type: :conflict, ours:"ANOTHER LINE OF TEXT\n",  base: "another line of text\n", theirs:"another LINE of text\n"},
+            {type: :non_conflict, text: "one more good line\n"},
+            {type: :conflict, ours:"thats about IT now\n", base:"thats about it now\n", theirs: "thats ABOUT it now\n"},
+            {type: :non_conflict, text: "this is the last line\n"},
+            {type: :conflict, ours: "WOOHOO!\n", base:"woohoo!\n", theirs:"wooHOO!\n"}
+          ]
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq expected_result
+          expect(result.results).to eq expected_result
+          expect(result.conflict?).to eq true
         end
 
         it 'should handle non overlapping changes without conflicts' do
@@ -304,9 +298,10 @@ describe Dyph3::Differ do
           ours            = "this is some text\nANOTHER LINE OF TEXT\none more good line\nthats about it now\nthis is the last line\n"
           theirs          = "this is some text\nanother line of text\none more good line\nthats ABOUT it now\nthis is the last line\n"
           expected_string = "this is some text\nANOTHER LINE OF TEXT\none more good line\nthats ABOUT it now\nthis is the last line\n"
-          expected_result = [expected_string, false, [{type: :non_conflict, text: expected_string }]]
+          expected_result = expected_string
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expect(result).to eq(expected_result)
+          expect(result.results).to eq(expected_result)
+          expect(result.success?).to eq(true)
         end
 
         context "both sides deleting, but one side deleting more" do
@@ -315,13 +310,13 @@ describe Dyph3::Differ do
             ours            = "another line of text"
             theirs          = "some text\nanother line of text"
 
-            expected_result = ["this is some text\nanother line of text",
-              true,
-              [{:type=>:conflict, :ours=>"", :base=>"this is some text\n", :theirs=>"some text\n"},
-              {:type=>:non_conflict, :text=>"another line of text"}]
+            expected_result = [
+              {:type=>:conflict, :ours=>"", :base=>"this is some text\n", :theirs=>"some text\n"},
+              {:type=>:non_conflict, :text=>"another line of text"}
             ]
             result = Dyph3::Differ.merge_text(ours, base, theirs)
-            expect(result).to eq(expected_result)
+            expect(result.results).to eq(expected_result)
+            expect(result.conflict?).to eq(true)
           end
 
           it "partial deletion of a middle line" do
@@ -329,16 +324,16 @@ describe Dyph3::Differ do
             ours            = "this is the first line\nanother line of text"
             theirs          = "this is the first line\nthis is\nanother line of text"
          #   expected_string = "this is the first line\nanother line of text"
-            expected_result = ["this is the first line\nthis is some text\nanother line of text",
-              true,
-              [{:type=>:non_conflict, :text=>"this is the first line\n"},
-               {:type=>:conflict,
+            expected_result = [
+              {:type=>:non_conflict, :text=>"this is the first line\n"},
+              { :type=>:conflict,
                 :ours=>"",
                 :base=>"this is some text\n",
                 :theirs=>"this is\n"},
-               {:type=>:non_conflict, :text=>"another line of text"}]]
+              { :type=>:non_conflict, :text=>"another line of text"}
+            ]
             result = Dyph3::Differ.merge_text(ours, base, theirs)
-            expect(result).to eq(expected_result)
+            expect(result.results).to eq(expected_result)
           end
         end
 
@@ -347,8 +342,8 @@ describe Dyph3::Differ do
           base = ''
           theirs = 'apricot'
           result = Dyph3::Differ.merge_text(ours, base, theirs)
-          expected_result = ["", true, [{type: :conflict, ours: "apple", base: "", theirs: "apricot"}]]
-          expect(result).to eq(expected_result)
+          expected_result = [{type: :conflict, ours: "apple", base: "", theirs: "apricot"}]
+          expect(result.results).to eq(expected_result)
         end
       end
 
@@ -357,31 +352,31 @@ describe Dyph3::Differ do
         non_trailing = "hi\nthis is text"
         it 'should not have a trailing newline where expected' do
           result1 = Dyph3::Differ.merge_text(non_trailing, non_trailing, non_trailing)
-          expect(result1[0][-1]).to_not eq("\n")
+          expect(result1.results[-1]).to_not eq("\n")
           
           result2 = Dyph3::Differ.merge_text(non_trailing, trailing, non_trailing)
-          expect(result2[0][-1]).to_not eq("\n")
+          expect(result2.results[-1]).to_not eq("\n")
           
           result3 = Dyph3::Differ.merge_text(non_trailing, trailing, trailing)
-          expect(result3[0][-1]).to_not eq("\n")
+          expect(result3.results[-1]).to_not eq("\n")
           
           result4 = Dyph3::Differ.merge_text(trailing, trailing, non_trailing)
-          expect(result4[0][-1]).to_not eq("\n")
+          expect(result4.results[-1]).to_not eq("\n")
         end
 
         it 'should have a trailing newline where expected' do
           result1 = Dyph3::Differ.merge_text(non_trailing, non_trailing, trailing)
-          expect(result1[0]).to eq(trailing)
-          expect(result1[0][-1]).to eq("\n")
+          expect(result1.results).to eq(trailing)
+          expect(result1.results[-1]).to eq("\n")
 
           result2 = Dyph3::Differ.merge_text(trailing, non_trailing, non_trailing)
-          expect(result2[0][-1]).to eq("\n")
+          expect(result2.results[-1]).to eq("\n")
 
           result3 = Dyph3::Differ.merge_text(trailing, non_trailing, trailing)
-          expect(result3[0][-1]).to eq("\n")
+          expect(result3.results[-1]).to eq("\n")
 
           result4 = Dyph3::Differ.merge_text(trailing, trailing, trailing)
-          expect(result4[0][-1]).to eq("\n")
+          expect(result4.results[-1]).to eq("\n")
 
         end
 
@@ -391,7 +386,7 @@ describe Dyph3::Differ do
           right = "\n<p>\nSome stuff\nAnd another line here\n</p>\nMore stuff here\n"
 
           result = Dyph3::Differ.merge_text(left, base, right)
-          expect(result[0]).to eq ['', '<p>', 'Some stuff', 'Added a line here', 'And another line here', '</p>', 'More stuff here', ''].join("\n")
+          expect(result.results).to eq ['', '<p>', 'Some stuff', 'Added a line here', 'And another line here', '</p>', 'More stuff here', ''].join("\n")
         end
 
         it "spot a conflict when left right and base don't agree" do
@@ -399,15 +394,14 @@ describe Dyph3::Differ do
           left = "Some stuff:\n<figref id=\"30835\"></figref>\n<p>\nThis calculation can</p>\n</p>\n"
           right = "Some stuff:\n<p>\nThis calculation can</p>\n<figref id=\"30836\"></figref>\n</p>\n"
           expected_result = [
-            base,
-            true,
-          [ {type: :non_conflict, text: "Some stuff:\n<figref id=\"30835\"></figref>\n<p>\nThis calculation can</p>\n"},
+           {type: :non_conflict, text: "Some stuff:\n<figref id=\"30835\"></figref>\n<p>\nThis calculation can</p>\n"},
             {type: :conflict, ours: "",
                               theirs: "<figref id=\"30836\"></figref>\n",
                               base: "\n\n"},
-            {type: :non_conflict, text: "</p>\n"}]]
-
-            expect(Dyph3::Differ.merge_text(left, base, right)).to eql expected_result
+            {type: :non_conflict, text: "</p>\n"}
+          ]
+          merged_text = Dyph3::Differ.merge_text(left, base, right)
+          expect(merged_text.results).to eql expected_result
         end
       end
     end

--- a/spec/lib/dyph3/support/collator_spec.rb
+++ b/spec/lib/dyph3/support/collator_spec.rb
@@ -2,38 +2,32 @@ require 'spec_helper'
 
 describe Dyph3::Support::Collater do
   let(:collator) { Dyph3::Support::Collater }
-  let(:text)     { "0\n1\n2\n3\n".split(/(\n)/) } 
+  let(:text)     { "0\n1\n2\n3\n".split(/(\n)/) }
+  let(:id)       { ->(x) { x} }
   [ lambda { |x| x.to_s } , lambda { |x| x.to_sym }, lambda { |x| Fish.new(x) } ].each do |f|
 
     describe ".collate_merge" do
       it "might be empty" do
-        results =  [[], false, [{type: :non_conflict, :text=>[]} ]]
-        expect(collator.collate_merge(f.call(""), f.call(""), f.call(""), [])).to eq results
+        results = [{type: :non_conflict, :text=>[]} ]
+        expect(collator.collate_merge([],id,nil).value).to eq results
       end
 
       it "might be have all non_conflicts" do
         collate_merge = text.map { |i| { type: :non_conflict, text: ["#{i}"] }}
-        result = [text, false,
-          [{:type=>:non_conflict, :text=>text}]]
-        expect(collator.collate_merge(text, text, text, collate_merge)).to eq result
+        result = [{:type=>:non_conflict, :text=>text}]
+        expect(collator.collate_merge(collate_merge, id, nil).value).to eq result
       end
 
       it "might be have all conflicts" do
         collate_merge = text.map { |i| { type: :conflicts, text: "#{i}" }}
-        result = [
-          text,
-          true,
-        collate_merge]
-        expect(collator.collate_merge(text, text, text, collate_merge)).to eq result
+        expect(collator.collate_merge(collate_merge, id, id).value).to eq collate_merge
       end
 
       it "might be a mixed bag" do
         conflicted_merge = text.map { |i| { type: :conflicts, text: ["#{i}"] }}
         non_conflected_merge = text.map { |i| { type: :non_conflict, text: ["#{i}"] }}
         merge_me = [conflicted_merge, non_conflected_merge].flatten
-        result = [
-          text,
-          true,
+        result =
         [{:type=>:conflicts, :text=>["0"]},
           {:type=>:conflicts, :text=>["\n"]},
           {:type=>:conflicts, :text=>["1"]},
@@ -43,8 +37,8 @@ describe Dyph3::Support::Collater do
           {:type=>:conflicts, :text=>["3"]},
           {:type=>:conflicts, :text=>["\n"]},
           {:type=>:non_conflict, :text=> text}
-        ]]
-        expect(collator.collate_merge(text, text, text, merge_me)).to eq result
+        ]
+        expect(collator.collate_merge(merge_me, id, id).value).to eq result
       end
     end
   end

--- a/spec/lib/dyph3/support/collator_spec.rb
+++ b/spec/lib/dyph3/support/collator_spec.rb
@@ -9,18 +9,18 @@ describe Dyph3::Support::Collater do
     describe ".collate_merge" do
       it "might be empty" do
         results = [{type: :non_conflict, :text=>[]} ]
-        expect(collator.collate_merge([],id,nil).value).to eq results
+        expect(collator.collate_merge([],id,nil).results).to eq results
       end
 
       it "might be have all non_conflicts" do
         collate_merge = text.map { |i| { type: :non_conflict, text: ["#{i}"] }}
         result = [{:type=>:non_conflict, :text=>text}]
-        expect(collator.collate_merge(collate_merge, id, nil).value).to eq result
+        expect(collator.collate_merge(collate_merge, id, nil).results).to eq result
       end
 
       it "might be have all conflicts" do
         collate_merge = text.map { |i| { type: :conflicts, text: "#{i}" }}
-        expect(collator.collate_merge(collate_merge, id, id).value).to eq collate_merge
+        expect(collator.collate_merge(collate_merge, id, id).results).to eq collate_merge
       end
 
       it "might be a mixed bag" do
@@ -38,7 +38,7 @@ describe Dyph3::Support::Collater do
           {:type=>:conflicts, :text=>["\n"]},
           {:type=>:non_conflict, :text=> text}
         ]
-        expect(collator.collate_merge(merge_me, id, id).value).to eq result
+        expect(collator.collate_merge(merge_me, id, id).results).to eq result
       end
     end
   end

--- a/spec/lib/dyph3/support/sanity_check_spec.rb
+++ b/spec/lib/dyph3/support/sanity_check_spec.rb
@@ -5,27 +5,25 @@ describe Dyph3::Support::SanityCheck do
   let(:error)          { Dyph3::Support::BadMergeException }
   describe ".ensure_no_lost_data" do
     it "should be calm if nothing happened" do
-      collated_text = [[""], false, [{type: :non_conflict, :text=>[""]}]]
+      collated_text = [{type: :non_conflict, :text=>[""]}]
       expect(sanity_checker.ensure_no_lost_data([""], [""], [""], collated_text)).to eq nil
     end
 
     it "should be calm if all the text is present" do
-      collated_text = [[""], false, [
+      collated_text = [
         {type: :non_conflict, :text=>["the dogs"]},
         {type: :non_conflict, :text=>["are"]},
         {type: :non_conflict, :text=>["out"]}
-        ]
       ]
       expect(sanity_checker.ensure_no_lost_data(["the dogs"], ["are"], ["out"], collated_text)).to eq nil
     end
 
     it "should raise and execption if the text is missing somewhere" do
-      collated_text = ["", false,
-        [
-          {type: :non_conflict, :text=>["the dogs are in"]},
-          {type: :non_conflict, :text=>["are"]},
-          {type: :non_conflict, :text=>["in"]}
-        ]
+      collated_text =
+      [
+        {type: :non_conflict, :text=>["the dogs are in"]},
+        {type: :non_conflict, :text=>["are"]},
+        {type: :non_conflict, :text=>["in"]}
       ]
 
       expect { sanity_checker.ensure_no_lost_data(["the"], ["dogs"], ["are out"], collated_text)}.to raise_error error


### PR DESCRIPTION
Wrap the output of the differ in a MergeResult class, either Success or Conflict.

The MergeResult class is responsible for applying the join or conflict functions. 

There are 3 output representations:
* The results, which is the pure result from the differ
* The typed_results, which are the same as the results, but with the join function applied to its text value
* The joined_results on a success object is its typed_results text values concatenated together. On a conflict object it attempts to use the conflict handler if any exist, other wise will return the typed_results.